### PR TITLE
Adds Sketch plugin info, cleans up CSS, updates ads

### DIFF
--- a/404.html
+++ b/404.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CMaterial+Icons">
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/ads.css">
+  <link rel="stylesheet" href="/css/carbon.css">
 </head>
 
 <body>
@@ -45,13 +45,7 @@
   <div class="page-content sub-page">
     <h1 class="page-title"><a href="/">Material Design Palette Generator</a></h1>
     <div class="mp-ad">
-      <a class="mp-ad-link" href="https://www.saasdesign.io/figma-material-design-desktop-kit/?utm_source=materialpalettes&utm_medium=banner&utm_campaign=material" target="_blank" rel="noopener sponsored">
-        <img class="mp-ad-image" alt="Figma Material Design UI kit and code" src="/images/material-ui-kit.png">
-        <div class="mp-ad-text">
-          <p>Premium Material Design UI templates for Figma.</p>
-          <p>Easy to customize. Code files available.</p>
-        </div>
-      </a>
+      <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CE7DKK37&placement=materialpalettescom" id="_carbonads_js"></script>
     </div>
     <div class="page-messaging">
       <p class="page-messaging-title">404</p>

--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@
 [<img src="/images/screenshot-1.png" />](https://materialpalettes.com)
 [<img src="/images/screenshot-2.png" />](https://materialpalettes.com)
 
-## Sponsor
-
-If you like this tool, be sure to check out the [Figma Material Design UI Kit](https://www.saasdesign.io/figma-material-design-desktop-kit/?utm_source=materialpalettes&utm_medium=banner&utm_campaign=material) and other design assets from [SaaS Design](https://www.saasdesign.io/).
-
-[<img src="/images/screenshot-3.png" />](https://www.saasdesign.io/figma-material-design-desktop-kit/?utm_source=materialpalettes&utm_medium=banner&utm_campaign=material)
-
 ## What is this?
 
 This is a (slightly modified) clone of the [official Material Design palette generator](https://material.io/design/color/the-color-system.html#tools-for-picking-colors). It does a couple things:
@@ -24,7 +18,9 @@ Google's official palette generator [is embedded and buried deep within the Mate
 
 To make it a little easier to access and to preserve it for my own future use, I grabbed the obfuscated code (the original scripts do not appear to be public anywhere) and added some small interface improvements. I did _not_ change the way colors are derived.
 
-The color output matches that produced in the [Material Theme Editor for Sketch](https://material.io/tools/theme-editor/), so it's a good companion for that.
+## Plugins
+
+After creating palettes and exporting the JSON data, Sketch users can create shared layer styles easily with the [Sketch JSON Color Palette Importer](https://github.com/ziyafenn/sketch-json-color-palette-importer) plugin.
 
 ## Support this project
 This tool will always be free but your support is greatly appreciated.

--- a/about.html
+++ b/about.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CMaterial+Icons">
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/ads.css">
+  <link rel="stylesheet" href="/css/carbon.css">
 </head>
 
 <body>
@@ -45,13 +45,7 @@
   <div class="page-content sub-page">
     <h1 class="page-title"><a href="/">Material Design Palette Generator</a></h1>
     <div class="mp-ad">
-      <a class="mp-ad-link" href="https://www.saasdesign.io/figma-material-design-desktop-kit/?utm_source=materialpalettes&utm_medium=banner&utm_campaign=material" target="_blank" rel="noopener sponsored">
-        <img class="mp-ad-image" alt="Figma Material Design UI kit and code" src="/images/material-ui-kit.png">
-        <div class="mp-ad-text">
-          <p>Premium Material Design UI templates for Figma.</p>
-          <p>Easy to customize. Code files available.</p>
-        </div>
-      </a>
+      <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CE7DKK37&placement=materialpalettescom" id="_carbonads_js"></script>
     </div>
     <div class="page-messaging">
       <h2>What is this?</h2>
@@ -65,7 +59,9 @@
       <h2>Why is this?</h2>
       <p>Google's official palette generator <a href="https://material.io/design/color/the-color-system.html#tools-for-picking-colors">is embedded and buried deep within the Material docs</a>. Since it's an inline tool, it's also hidden from search engines, making it difficult to discover or bookmark.</p>
       <p>To make it a little easier to access and to preserve it for my own future use, I grabbed the obfuscated code (the original scripts do not appear to be public anywhere) and added some small interface improvements. I did <em>not</em> change the way colors are derived.</p>
-      <p>The color output matches that produced in the <a href="https://material.io/tools/theme-editor/">Material Theme Editor for Sketch</a>, so it's a good companion for that.</p>
+
+      <h2>Plugins</h2>
+      <p>After creating palettes and exporting the JSON data, Sketch users can create shared layer styles easily with the <a href="https://github.com/ziyafenn/sketch-json-color-palette-importer">Sketch JSON Color Palette Importer</a> plugin.
 
       <h2 id="support">Support this project</h2>
       <p>This tool will always be free but your support is greatly appreciated.</p>
@@ -76,12 +72,6 @@
         <li><a href="https://www.paypal.me/edelstone">Paypal</a></li>
         <li>Bitcoin: <code>39t7oofR7AoZoAdH7gJLBrGnrgcJbsqmiP</code></li>
       </ul>
-
-      <h2>Sponsor</h2>
-      <p>If you like this tool, be sure to check out the <a href="https://www.saasdesign.io/figma-material-design-desktop-kit/?utm_source=materialpalettes&utm_medium=banner&utm_campaign=material">Figma Material Design UI Kit</a> and other design assets from <a href="https://www.saasdesign.io/">SaaS Design</a>.
-      <a href="https://www.saasdesign.io/figma-material-design-desktop-kit/?utm_source=materialpalettes&utm_medium=banner&utm_campaign=material">
-        <img class="screenshot" alt="Figma Material Design desktop kit" src="/images/screenshot-3.png">
-      </a>
 
       <h2>Feedback and contributing</h2>
       <p>If you notice a problem or want a feature added please <a href="https://github.com/edelstone/material-palette-generator/issues/new">file an issue on GitHub</a>. You can also just <a href="mailto:michael.edelstone@gmail.com">email me</a> the details.</p>

--- a/css/carbon.css
+++ b/css/carbon.css
@@ -57,7 +57,7 @@
   padding: 5px 6px;
   border-radius: 2.5px;
   background-color: hsl(246, 93%, 69%);
-  color: #fff !important;
+  color: #fff;
   text-transform: uppercase;
   letter-spacing: .5px;
   font-weight: 600;
@@ -72,6 +72,10 @@
 	right: 20px;
 	top: 60px;
 	max-width: 240px;
+}
+
+.carbon-img img {
+  border: 1px solid #424242;
 }
 
 .sub-page .mp-ad {
@@ -89,13 +93,17 @@
 
 .carbon-text {
   font-weight: 400;
-  padding: 0 15px;
+  padding: 0 10px;
+  margin: 12px 0;
+  line-height: 1.4;
 }
 
 .carbon-poweredby {
-  background: #767676;
-  font-weight: 500;
-  padding: 6px 8px;
+  background: none;
+  padding: 0;
+  color: #424242;
+  right: 12px;
+  bottom: 12px;
 }
 
 @media screen and (max-width: 1000px) {
@@ -129,11 +137,6 @@
   .carbon-text {
     text-align: left;
     font-size: 14px;
-  }
-}
-
-@media screen and (max-width: 350px) {
-  .carbon-text {
-    margin-bottom: 40px;
+    margin: 0;
   }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -197,6 +197,100 @@ img {
   margin-right: 25px;
 }
 
+/* Modal */
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+}
+
+.modal-content {
+  background-color: #ececec;
+  margin: 50px auto 0;
+  padding: 20px;
+  max-width: 600px;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.25), 0 2px 4px rgba(0,0,0,0.25), 0 4px 8px rgba(0,0,0,0.25), 0 8px 16px rgba(0,0,0,0.25), 0 16px 32px rgba(0,0,0,0.25), 0 32px 64px rgba(0,0,0,0.25);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-weight: 500;
+  color: #212121;
+}
+
+.close {
+  color: #212121;
+  font-size: 32px;
+  font-weight: 500;
+  border: none;
+  padding: 0;
+  background: #d9d9d9;
+  border-radius: 3px;
+  width: 36px;
+  height: 36px;
+  line-height: 0;
+  transition: background .15s ease-in-out;
+}
+
+.close:focus,
+.close:hover {
+  cursor: pointer;
+  background: #c6c6c6;
+}
+
+textarea {
+  resize: none;
+  width: 100%;
+  height: 60vh;
+  font-size: 16px;
+  line-height: 1.4;
+  border: 1px solid #c6c6c6;
+  border-radius: 4px;
+  color: #212121;
+}
+
+.buttonContainer {
+  margin-top: 50px;
+}
+
+.exportButton {
+  padding: 20px 25px;
+  cursor: pointer;
+  text-transform: uppercase;
+  background-color: #212121;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  transition: background-color .15s ease-in-out;
+}
+
+.exportButton:active,
+.exportButton:focus,
+.exportButton:hover {
+  background-color: #424242;
+}
+
 @media screen and (max-width: 1000px) {
   body {
     background-color: #fff;
@@ -282,119 +376,4 @@ img {
   .github-corner .octo-arm {
     animation: octocat-wave 560ms ease-in-out;
   }
-}
-
-/* The Modal (background) */
-.modal {
-  display: none;
-  position: fixed; /* Stay in place */
-  z-index: 1; /* Sit on top */
-  left: 0;
-  top: 0;
-  width: 100%; /* Full width */
-  height: 100%; /* Full height */
-  overflow: auto; /* Enable scroll if needed */
-  background-color: rgb(0, 0, 0); /* Fallback color */
-  background-color: rgba(0, 0, 0, 0.75); /* Black w/ opacity */
-}
-
-/* Modal Content/Box */
-.modal-content {
-  background-color: #fefefe;
-  margin: 48px auto; /* 15% from the top and centered */
-  padding: 20px;
-  border: 1px solid #888;
-  width: 80%; /* Could be more or less, depending on screen size */
-  max-width: 640px;
-}
-
-/* The Close Button */
-.close {
-  color: #aaa;
-  float: right;
-  font-size: 28px;
-  font-weight: bold;
-  background: none;
-  border: 0;
-}
-
-.close:hover,
-.close:focus {
-  color: black;
-  text-decoration: none;
-  cursor: pointer;
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 16px;
-}
-
-.modal-header h3 {
-  margin: 0;
-}
-
-/* TextArea */
-textarea {
-  resize: none;
-  width: 100%;
-  max-width: 600px;
-  height: 60vh;
-  font-size: 16px;
-  line-height: 1.5;
-}
-
-/* Export Button */
-
-.buttonContainer {
-  padding-top: 56px;
-}
-.exportButton {
-  display: flex;
-  overflow: hidden;
-
-  padding: 16px 16px;
-
-  cursor: pointer;
-  user-select: none;
-  transition: all 150ms linear;
-  text-align: center;
-  white-space: nowrap;
-  text-decoration: none;
-  text-transform: uppercase;
-
-  background-color: #212121;
-  color: #fff;
-  border: 0 none;
-  border-radius: 3px;
-
-  font-size: 14px;
-  font-weight: bold;
-  line-height: 1.3;
-  letter-spacing: 3px;
-
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-
-  justify-content: center;
-  align-items: center;
-  flex: 0 0 160px;
-}
-
-.button:hover {
-  transition: all 150ms linear;
-  opacity: 0.85;
-}
-
-.button:active {
-  transition: all 150ms linear;
-  opacity: 0.75;
-}
-
-.button:focus {
-  outline: 1px solid #959595;
-  outline-offset: -4px;
 }

--- a/index.html
+++ b/index.html
@@ -1,125 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=UA-152202722-1"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
+<head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-152202722-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-      gtag("config", "UA-152202722-1");
-    </script>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <meta
-      name="description"
-      content="Get perfect Material Design color palettes from any hex color."
-    />
-    <title>Material Design Palette Generator</title>
-    <meta name="title" content="Material Design Palette Generator" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="manifest" href="/site.webmanifest" />
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0878a0" />
-    <link rel="canonical" href="https://materialpalettes.com" />
-    <meta name="msapplication-TileColor" content="#00aba9" />
-    <meta name="theme-color" content="#ffffff" />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://materialpalettes.com" />
-    <meta property="og:title" content="Material Design Palette Generator" />
-    <meta
-      property="og:description"
-      content="Get perfect Material Design color palettes from any hex color."
-    />
-    <meta
-      property="og:image"
-      content="https://materialpalettes.com/images/og-image.jpg"
-    />
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://materialpalettes.com" />
-    <meta
-      property="twitter:title"
-      content="Material Design Palette Generator"
-    />
-    <meta
-      property="twitter:description"
-      content="Get perfect Material Design color palettes from any hex color."
-    />
-    <meta
-      property="twitter:image"
-      content="https://materialpalettes.com/images/og-image.jpg"
-    />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CMaterial+Icons"
-    />
-    <link rel="stylesheet" href="/css/main.css" />
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/ads.css" />
-  </head>
+    gtag('config', 'UA-152202722-1');
+  </script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <meta name="description" content="Get perfect Material Design color palettes from any hex color.">
+  <title>Material Design Palette Generator</title>
+  <meta name="title" content="Material Design Palette Generator">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0878a0">
+  <link rel="canonical" href="https://materialpalettes.com">
+  <meta name="msapplication-TileColor" content="#00aba9">
+  <meta name="theme-color" content="#ffffff">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://materialpalettes.com">
+  <meta property="og:title" content="Material Design Palette Generator">
+  <meta property="og:description" content="Get perfect Material Design color palettes from any hex color.">
+  <meta property="og:image" content="https://materialpalettes.com/images/og-image.jpg">
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="https://materialpalettes.com">
+  <meta property="twitter:title" content="Material Design Palette Generator">
+  <meta property="twitter:description" content="Get perfect Material Design color palettes from any hex color.">
+  <meta property="twitter:image" content="https://materialpalettes.com/images/og-image.jpg">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CMaterial+Icons">
+  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/css/carbon.css">
+</head>
 
-  <body>
-    <a
-      href="https://github.com/edelstone/material-palette-generator"
-      class="github-corner"
-      aria-label="View source on GitHub"
-      ><svg
-        width="80"
-        height="80"
-        viewBox="0 0 250 250"
-        style="
-          fill: #212121;
-          color: #fff;
-          position: absolute;
-          top: 0;
-          border: 0;
-          left: 0;
-          transform: scale(-1, 1);
-        "
-        aria-hidden="true"
-      >
-        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
-        <path
-          d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
-          fill="currentColor"
-          style="transform-origin: 130px 106px;"
-          class="octo-arm"
-        ></path>
-        <path
-          d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
-          fill="currentColor"
-          class="octo-body"
-        ></path></svg
-    ></a>
+<body>
+  <a href="https://github.com/edelstone/material-palette-generator" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#212121; color:#fff; position: absolute; top: 0; border: 0; left: 0; transform: scale(-1, 1);" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
     <div class="page-content">
       <h1 class="page-title">
         <a href="/">Material Design Palette Generator</a>
       </h1>
       <div class="mp-ad">
-        <a
-          class="mp-ad-link"
-          href="https://www.saasdesign.io/figma-material-design-desktop-kit/?utm_source=materialpalettes&utm_medium=banner&utm_campaign=material"
-          target="_blank"
-          rel="noopener sponsored"
-        >
-          <img
-            class="mp-ad-image"
-            alt="Figma Material Design UI kit and code"
-            src="/images/material-ui-kit.png"
-          />
-          <div class="mp-ad-text">
-            <p>Premium Material Design UI templates for Figma.</p>
-            <p>Easy to customize. Code files available.</p>
-          </div>
-        </a>
+        <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CE7DKK37&placement=materialpalettescom" id="_carbonads_js"></script>
       </div>
     </div>
     <div class="palettes" id="root-container"></div>
@@ -130,26 +58,21 @@
         <a class="standard-link" href="/about#support">Support this project</a>
       </p>
     </div>
-    <!-- The Modal -->
+
+    <!-- Modal -->
     <dialog id="exportModal" class="modal">
-      <!-- Modal content -->
       <div class="modal-content">
         <div class="modal-header">
           <h3>JSON Color Palette</h3>
           <button class="close" type="reset">&times;</button>
         </div>
         <div>
-          <textarea
-            name="exportedPalettes"
-            onclick="this.select()"
-            readonly
-            id="jsonText"
-          ></textarea>
+          <textarea name="exportedPalettes" onclick="this.select()" readonly id="jsonText"></textarea>
         </div>
       </div>
     </dialog>
     <script src="/js/main.js" defer></script>
     <script src="/js/export.js" defer></script>
-    <script></script>
+    <script> </script>
   </body>
 </html>


### PR DESCRIPTION
• Adds Sketch plugin info to README and about pages
• Tweaks modal and dialog design a bit
• Cleans up and organizes CSS
• Removes custom ad and adds Carbon ads
• Fixes issue where transitions fire on page load

Note: The reason transitions fired on page load in Chrome is explained in [this Stack Overflow answer](https://stackoverflow.com/a/42969608/2127167). When the linter reformatted things in #5, the space between the `<script>` tags was removed.