### PR TITLE
Export palette as CSS Variables

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3,14 +3,17 @@ Just some local overrides so Google's original stylesheet (main.css) can remain 
 */
 
 @keyframes octocat-wave {
+
   0%,
   100% {
     transform: rotate(0);
   }
+
   20%,
   60% {
     transform: rotate(-25deg);
   }
+
   40%,
   80% {
     transform: rotate(10deg);
@@ -143,8 +146,7 @@ img {
   display: none;
 }
 
-.utility-panel {
-}
+.utility-panel {}
 
 .utility-panel__label {
   cursor: default;
@@ -227,6 +229,10 @@ img {
   align-items: center;
   margin-bottom: 20px;
   height: 40px;
+}
+
+.modal-contol {
+  padding-block: 5px;
 }
 
 .modal-header h3 {

--- a/css/styles.css
+++ b/css/styles.css
@@ -233,7 +233,7 @@ img {
   height: 40px;
 }
 
-.modal-contol {
+.modal-control {
   padding-block: 5px;
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -221,6 +221,8 @@ img {
   padding: 20px;
   max-width: 600px;
   border-radius: 4px;
+  display: flex;
+  flex-direction: column;
 }
 
 .modal-header {

--- a/index.html
+++ b/index.html
@@ -42,18 +42,7 @@
 </head>
 
 <body>
-  <a href="https://github.com/edelstone/material-palette-generator" class="github-corner"
-    aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250"
-      style="fill:#212121; color:#fff; position: absolute; top: 0; border: 0; left: 0; transform: scale(-1, 1);"
-      aria-hidden="true">
-      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
-      <path
-        d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
-        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
-      <path
-        d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
-        fill="currentColor" class="octo-body"></path>
-    </svg></a>
+  <a href="https://github.com/edelstone/material-palette-generator" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#212121; color:#fff; position: absolute; top: 0; border: 0; left: 0; transform: scale(-1, 1);" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
   <div class="page-content">
     <h1 class="page-title">
       <a href="/">Material Design Palette Generator</a>
@@ -79,7 +68,7 @@
         <h3>Color palette</h3>
         <button class="close" type="reset"><i class="material-icons">highlight_off</i></button>
       </div>
-      <div class="modal-contol">
+      <div class="modal-control">
         <label for="export-type">Type:</label>
         <select name="type" id="export-type" onchange="ExportColor()">
           <option value="json" selected>JSON</option>

--- a/index.html
+++ b/index.html
@@ -34,15 +34,25 @@
   <meta name="twitter:title" content="Material Design Palette Generator">
   <meta name="twitter:description" content="Get perfect Material Design color palettes from any hex color.">
   <meta name="twitter:image" content="https://materialpalettes.com/images/og-image.jpg">
-  <link rel="stylesheet"
-    href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CMaterial+Icons%7CRoboto+Mono">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CMaterial+Icons%7CRoboto+Mono">
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/styles.css">
   <link rel="stylesheet" href="/css/carbon.css">
 </head>
 
 <body>
-  <a href="https://github.com/edelstone/material-palette-generator" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#212121; color:#fff; position: absolute; top: 0; border: 0; left: 0; transform: scale(-1, 1);" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
+  <a href="https://github.com/edelstone/material-palette-generator" class="github-corner"
+    aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250"
+      style="fill:#212121; color:#fff; position: absolute; top: 0; border: 0; left: 0; transform: scale(-1, 1);"
+      aria-hidden="true">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path
+        d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path
+        d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg></a>
   <div class="page-content">
     <h1 class="page-title">
       <a href="/">Material Design Palette Generator</a>

--- a/index.html
+++ b/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-152202722-1"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
     gtag('config', 'UA-152202722-1');
@@ -33,56 +34,77 @@
   <meta name="twitter:title" content="Material Design Palette Generator">
   <meta name="twitter:description" content="Get perfect Material Design color palettes from any hex color.">
   <meta name="twitter:image" content="https://materialpalettes.com/images/og-image.jpg">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CMaterial+Icons%7CRoboto+Mono">
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CMaterial+Icons%7CRoboto+Mono">
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/styles.css">
   <link rel="stylesheet" href="/css/carbon.css">
 </head>
 
 <body>
-  <a href="https://github.com/edelstone/material-palette-generator" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#212121; color:#fff; position: absolute; top: 0; border: 0; left: 0; transform: scale(-1, 1);" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
-    <div class="page-content">
-      <h1 class="page-title">
-        <a href="/">Material Design Palette Generator</a>
-      </h1>
-      <div class="mp-ad">
-        <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CE7DKK37&placement=materialpalettescom" id="_carbonads_js"></script>
+  <a href="https://github.com/edelstone/material-palette-generator" class="github-corner"
+    aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250"
+      style="fill:#212121; color:#fff; position: absolute; top: 0; border: 0; left: 0; transform: scale(-1, 1);"
+      aria-hidden="true">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path
+        d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path
+        d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg></a>
+  <div class="page-content">
+    <h1 class="page-title">
+      <a href="/">Material Design Palette Generator</a>
+    </h1>
+    <div class="mp-ad">
+      <script async type="text/javascript"
+        src="//cdn.carbonads.com/carbon.js?serve=CE7DKK37&placement=materialpalettescom" id="_carbonads_js"></script>
+    </div>
+  </div>
+  <div class="palettes" id="root-container"></div>
+
+  <div class="page-footer">
+    <p>
+      <a class="standard-link" href="/about">About</a>
+      <a class="standard-link" href="/about#support">Support this project</a>
+    </p>
+  </div>
+
+  <!-- Modal -->
+  <dialog id="exportModal" class="modal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>Color palette</h3>
+        <button class="close" type="reset"><i class="material-icons">highlight_off</i></button>
+      </div>
+      <div class="modal-contol">
+        <label for="export-type">Type:</label>
+        <select name="type" id="export-type" onchange="ExportColor()">
+          <option value="json" selected>JSON</option>
+          <option value="css">CSS</option>
+        </select>
+      </div>
+      <div class="modal-text">
+        <textarea name="exportedPalettes" onclick="this.select()" readonly id="jsonText"></textarea>
       </div>
     </div>
-    <div class="palettes" id="root-container"></div>
+  </dialog>
+  <script src="/js/main.js" defer></script>
+  <script src="/js/export.js" defer></script>
+  <script src="/js/jquery-3.5.1.min.js"></script>
+  <script>
+    // Show a new Carbon ad every time when certain elements are clicked
+    $(document).on('click', '.color-palette__cell, .utility-panel__color-entry, .color-picker, .exportButton, .carbon-img, .carbon-text, .carbon-poweredby', function () {
+      // If the ad hasn't loaded yet, don't refresh it while it's still loading, or it will return two (or more) ads
+      if (!$("#carbonads")[0]) return;
+      // If the script hasn't loaded, don't try calling it
+      if (typeof _carbonads !== 'undefined') _carbonads.refresh();
+    });
+  </script>
+  <!-- Empty script tags below keep CSS transitions from firing on page load. It's a Chrome bug. See here: https://stackoverflow.com/questions/14389566/stop-css-transition-from-firing-on-page-load/42969608#42969608 -->
+  <script> </script>
+</body>
 
-    <div class="page-footer">
-      <p>
-        <a class="standard-link" href="/about">About</a>
-        <a class="standard-link" href="/about#support">Support this project</a>
-      </p>
-    </div>
-
-    <!-- Modal -->
-    <dialog id="exportModal" class="modal">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h3>JSON color palette</h3>
-          <button class="close" type="reset"><i class="material-icons">highlight_off</i></button>
-        </div>
-        <div class="modal-text">
-          <textarea name="exportedPalettes" onclick="this.select()" readonly id="jsonText"></textarea>
-        </div>
-      </div>
-    </dialog>
-    <script src="/js/main.js" defer></script>
-    <script src="/js/export.js" defer></script>
-    <script src="/js/jquery-3.5.1.min.js"></script>
-    <script>
-      // Show a new Carbon ad every time when certain elements are clicked
-      $(document).on('click', '.color-palette__cell, .utility-panel__color-entry, .color-picker, .exportButton, .carbon-img, .carbon-text, .carbon-poweredby', function() {
-        // If the ad hasn't loaded yet, don't refresh it while it's still loading, or it will return two (or more) ads
-        if (!$("#carbonads")[0]) return;
-        // If the script hasn't loaded, don't try calling it
-        if (typeof _carbonads !== 'undefined') _carbonads.refresh();
-      });
-    </script>
-    <!-- Empty script tags below keep CSS transitions from firing on page load. It's a Chrome bug. See here: https://stackoverflow.com/questions/14389566/stop-css-transition-from-firing-on-page-load/42969608#42969608 -->
-    <script> </script>
-  </body>
 </html>

--- a/js/export.js
+++ b/js/export.js
@@ -1,6 +1,7 @@
 const modal = document.querySelector(".modal");
 
 function ExportColor() {
+  const exportType = document.querySelector('select#export-type')?.value;
   const colorPalettes = document.querySelectorAll(".color-palette__row");
   const colorSelector = document.querySelectorAll(
     ".color-palette__cell-hex-value"
@@ -132,14 +133,48 @@ function ExportColor() {
     });
   }
 
-  textArea.textContent = JSON.stringify(exported, null, "  ");
+  switch (exportType) {
+    case 'css':
+      textArea.textContent = convertJSONtoCSS(exported);
+      break;
+    case 'json':
+      textArea.textContent = JSON.stringify(exported, null, "  ");
+      break;
+    default:
+      textArea.textContent = JSON.stringify(exported, null, "  ")
+  }
+
   modal.style.display = "block";
+
+}
+
+function convertJSONtoCSS(paletteJSON) {
+  const paletteCSS = [];
+  const mainColors = [];
+
+  [...document.querySelectorAll('.color-palette__cell--selected')].forEach(mainColorElement => {
+    mainColors.push(mainColorElement.querySelector('.color-palette__cell-hex-value').textContent)
+  });
+
+  for (const color in paletteJSON) {
+    const colorName = color.replace(/ /g,'').toLowerCase();
+    Object.entries(paletteJSON[color]).forEach(colorShade => {
+      paletteCSS.push(`--clr-${colorName}-${colorShade[0]}: ${colorShade[1]};`);
+      if (mainColors.includes(colorShade[1])) {
+        paletteCSS.push(`--clr-${colorName}: var(--clr-${colorName}-${colorShade[0]});`);
+      } 
+    });
+  }
+
+  //return paletteCSS;
+  return `:root {\n\t${paletteCSS.join('\n\t')}\n\n}`;
 }
 
 // Controls
 
 const closeButton = document.querySelector(".close");
 const contentArea = document.querySelector(".color-tool");
+const exportTypeSelect = document.querySelector('select#export-type');
 
 contentArea.insertAdjacentHTML(
   "beforeend",


### PR DESCRIPTION
In this Pull Request (PR), I would like to introduce a new feature to this repository that enables exporting the colour palette to CSS variables format. In my opinion, it's useful functionality and may reduce the time spent on copying and pasting all colours from the generator to CSS.

**Changes introduced in the Pull Request (PR):**

1. CSS Variable Export Function:

    I added a new function called convertJSONtoCSS that converts the color palette from JSON format into CSS variables. This function processes each color and its shades, creating corresponding CSS variables. For each color, a variable is created in the format --clr-{colorName}-{shadeLabel}: {colorValue};, and a main variable for that color is also defined.

    Example:
    For the 'Primary' color, we obtain the defined CSS variables:
    ```css
    --clr-primary-100: #112233;
    --clr-primary-200: #445566;
    --clr-primary: var(--clr-primary-200);
    ```

2. No changes to the color format:
The function currently accepts the color palette in HEX format, maintaining consistency with the existing application code.

3. Testing:
I conducted tests for the convertJSONtoCSS function and ensured that it correctly generates CSS variables for each color and its shades from the JSON-format palette. The tests were successful, and the function behaves as expected.

4. Impact on existing code:
The introduced changes do not negatively impact the existing code. The new function has been seamlessly integrated with the existing components and adapted to the current application logic.

5. How it works in practice? User can export palette and select what type of export would get.

![image](https://github.com/edelstone/material-palette-generator/assets/55158818/e6a85279-e3a9-470e-8273-4bcaf5c4db67)
![image](https://github.com/edelstone/material-palette-generator/assets/55158818/dde7ade5-b681-4570-8989-f7f58fd0f200)
